### PR TITLE
Simplify build

### DIFF
--- a/full-node/.gitignore
+++ b/full-node/.gitignore
@@ -1,0 +1,5 @@
+# Temporary build results
+tmp/
+
+# Output folder for binary and libs
+out/

--- a/full-node/Dockerfile
+++ b/full-node/Dockerfile
@@ -8,7 +8,7 @@ RUN ./setup.sh
 # Finds dynamic libraries installed in the Go package management system, like
 #   /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v1.0.0/api/libwasmvm.aarch64.so
 #   /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v1.0.0/api/libwasmvm.x86_64.so
-RUN find "$GOPATH/pkg" -type f -name 'libwasm*.so' -exec cp {} /go/wasmd/build \;
+RUN find "$GOPATH/pkg" -type f -name 'libwasm*.so' -exec cp {} /go/out \;
 
 FROM ubuntu:20.04
 ENV LD_LIBRARY_PATH=/root
@@ -16,7 +16,7 @@ ENV PATH=$PATH:/root
 RUN apt-get update && apt-get install -y \
     curl \
  && rm -rf /var/lib/apt/lists/*
-COPY --from=go_builder /go/wasmd/build/$BINARY_NAME /root/$BINARY_NAME
-COPY --from=go_builder /go/wasmd/build/libwasmvm*.so /root
+COPY --from=go_builder /go/out/$BINARY_NAME /root/$BINARY_NAME
+COPY --from=go_builder /go/out/libwasmvm*.so /root
 COPY startup.sh .
 ENTRYPOINT ["./startup.sh"]

--- a/full-node/setup.sh
+++ b/full-node/setup.sh
@@ -7,25 +7,29 @@ BECH32_PREFIX=nois
 WASMD_VERSION=0.28.0
 WASMD_TAG="v$WASMD_VERSION"
 
+rm -rf tmp || true
+mkdir tmp
 
-if [ ! -d "wasmd" ] 
-then
+(
+  cd tmp
   git clone https://github.com/CosmWasm/wasmd.git
-  cd wasmd
-  git checkout "${WASMD_TAG}"
-  WASMD_COMMIT_HASH=$(git rev-parse HEAD)
-  mkdir build
-  go build \
-      -o build/$BINARY_NAME -mod=readonly -tags "netgo,ledger" \
-      -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name=$BINARY_NAME \
-      -X github.com/cosmos/cosmos-sdk/version.AppName=$BINARY_NAME \
-      -X github.com/CosmWasm/wasmd/app.NodeDir=.$BINARY_NAME \
-      -X github.com/cosmos/cosmos-sdk/version.Version=${WASMD_VERSION} \
-      -X github.com/cosmos/cosmos-sdk/version.Commit=${WASMD_COMMIT_HASH} \
-      -X github.com/CosmWasm/wasmd/app.Bech32Prefix=${BECH32_PREFIX} \
-      -X 'github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger'" \
-      -trimpath ./cmd/wasmd
-else
-     echo "wasmd already cloned. not going to compile"
-     cd wasmd
-fi
+  (
+    cd wasmd
+    git checkout "${WASMD_TAG}"
+    WASMD_COMMIT_HASH=$(git rev-parse HEAD)
+    mkdir build
+    go build \
+        -o build/$BINARY_NAME -mod=readonly -tags "netgo,ledger" \
+        -ldflags "-X github.com/cosmos/cosmos-sdk/version.Name=$BINARY_NAME \
+        -X github.com/cosmos/cosmos-sdk/version.AppName=$BINARY_NAME \
+        -X github.com/CosmWasm/wasmd/app.NodeDir=.$BINARY_NAME \
+        -X github.com/cosmos/cosmos-sdk/version.Version=${WASMD_VERSION} \
+        -X github.com/cosmos/cosmos-sdk/version.Commit=${WASMD_COMMIT_HASH} \
+        -X github.com/CosmWasm/wasmd/app.Bech32Prefix=${BECH32_PREFIX} \
+        -X 'github.com/cosmos/cosmos-sdk/version.BuildTags=netgo,ledger'" \
+        -trimpath ./cmd/wasmd
+  )
+)
+
+mkdir -p out
+cp tmp/wasmd/build/noisd out

--- a/full-node/setup.sh
+++ b/full-node/setup.sh
@@ -7,8 +7,8 @@ BECH32_PREFIX=nois
 WASMD_VERSION=0.28.0
 WASMD_TAG="v$WASMD_VERSION"
 
-rm -rf tmp || true
-mkdir tmp
+# Re-create tmp directory
+rm -rf tmp && mkdir tmp
 
 (
   cd tmp

--- a/full-node/setup.sh
+++ b/full-node/setup.sh
@@ -12,10 +12,9 @@ rm -rf tmp && mkdir tmp
 
 (
   cd tmp
-  git clone https://github.com/CosmWasm/wasmd.git
+  git clone --depth 1 --branch "${WASMD_TAG}" https://github.com/CosmWasm/wasmd.git
   (
     cd wasmd
-    git checkout "${WASMD_TAG}"
     WASMD_COMMIT_HASH=$(git rev-parse HEAD)
     mkdir build
     go build \


### PR DESCRIPTION
This gives you less trouble building because a tmp directory is created and cleared for every run.